### PR TITLE
replace new builder item keyframe animation

### DIFF
--- a/includes/option-types/builder/static/css/builder.css
+++ b/includes/option-types/builder/static/css/builder.css
@@ -326,19 +326,19 @@ body.rtl .fw-option-type-builder .builder-item-type {
 }
 
 .fw-option-type-builder .builder-items .builder-item.new-item {
-	animation: fwGrowIn .3s ease-in-out;
+	animation: fwDropIn .3s ease-in-out;
 	animation-iteration-count: 1;
 
-	-webkit-animation: fwGrowIn .3s ease-in-out;
+	-webkit-animation: fwDropIn .3s ease-in-out;
 	-webkit-animation-iteration-count: 1;
 
-	-moz-animation: fwGrowIn .3s ease-in-out;
+	-moz-animation: fwDropIn .3s ease-in-out;
 	-moz-animation-iteration-count: 1;
 
-	-o-animation: fwGrowIn .3s ease-in-out;
+	-o-animation: fwDropIn .3s ease-in-out;
 	-o-animation-iteration-count: 1;
 
-	-ms-animation: fwGrowIn .3s ease-in-out;
+	-ms-animation: fwDropIn .3s ease-in-out;
 	-ms-animation-iteration-count: 1;
 }
 


### PR DESCRIPTION
Use a better looking keyframe for new builder items:
![](https://i.gyazo.com/9defeb4f9cb67b54132c9b3d83acaedf.gif)

The [old one](https://i.gyazo.com/5b651f0cba472fa6dbbe0cdba3b23042.gif) wasn't so clear about the action that's happening.
