### PR TITLE
Uncomment the container responsive size

### DIFF
--- a/static/css/frontend-grid.css
+++ b/static/css/frontend-grid.css
@@ -100,7 +100,7 @@ embed {
 	padding-right: 15px;
 }
 
-/*@media (min-width: 768px) {
+@media (min-width: 768px) {
 	.fw-container {
 		width: 750px;
 	}
@@ -114,7 +114,7 @@ embed {
 	.fw-container {
 		width: 1170px;
 	}
-}*/
+}
 .fw-container-fluid {
 	position: relative;
 	margin-right: auto;


### PR DESCRIPTION
Why this responsive rule commented out? It make the fullwidth option on
section not work.

So there is no different between .fw-container and .fw-container-fluid.
