### PR TITLE
introduce fw_builder_has_template_saving_feature filter

### DIFF
--- a/includes/option-types/builder/includes/templates/class-fw-ext-builder-templates.php
+++ b/includes/option-types/builder/includes/templates/class-fw-ext-builder-templates.php
@@ -90,7 +90,13 @@ final class FW_Ext_Builder_Templates
 	 */
 	public static function _action_builder_enqueue($data)
 	{
-		if (!$data['option']['template_saving']) {
+		if (!
+			apply_filters(
+				'fw_builder_has_template_saving_feature',
+				$data['option']['template_saving'],
+				$data['option']
+			)
+		) {
 			return;
 		}
 


### PR DESCRIPTION
This filter allows you to disable templates feature for a specific builder.

```php
add_filter('fw_builder_has_template_saving_feature', 'callback', 10, 2);

function callback($has_template_saving, $option) {
  if ($option['type'] === 'builder-you-are-looking-for') {
    return false;
  }

  // do not break the chain for other builders
  return $has_template_saving;
}

```