### PR TITLE
feat($sortable): implement sortable hooks

### DIFF
--- a/includes/option-types/builder/static/js/builder.js
+++ b/includes/option-types/builder/static/js/builder.js
@@ -392,9 +392,16 @@ jQuery( document ).ready( function ( $ ) {
 
 							var rearrangeTimeout;
 
-							this.$el.sortable( {
-								helper: 'original',
+							var additionalSortableOptions = {}
+
+							fwEvents.trigger(
+								'fw-builder:'+ builder.get('type') +':sortable-additional-options',
+								additionalSortableOptions
+							)
+
+							this.$el.sortable(_.extend({
 								items: '> .builder-item',
+								helper: 'original',
 								connectWith: '#' + builder.$input.closest( '.fw-option-type-builder' ).attr( 'id' ) + ' .builder-root-items .builder-items',
 								distance: 10,
 								opacity: 0.6,
@@ -501,6 +508,10 @@ jQuery( document ).ready( function ( $ ) {
 										                       .find( '.builder-root-items > .builder-items' );
 
 										container.css( 'min-height', '' );
+									}
+
+									if (ui.helper) {
+										$(ui.helper).remove()
 									}
 								},
 								receive: function ( event, ui ) {
@@ -655,7 +666,7 @@ jQuery( document ).ready( function ( $ ) {
 										collection.add( item, {at: index} );
 									}
 								}
-							} );
+							}, additionalSortableOptions) );
 
 							/**
 							 * Delay placeholder possition change to prevent "jumping"

--- a/includes/option-types/builder/static/js/initialize-builder.js
+++ b/includes/option-types/builder/static/js/initialize-builder.js
@@ -117,7 +117,14 @@ window.fwExtBuilderInitialize = (function ($) {
 	function initDraggable ($this, builder, id) {
 		fwEvents.trigger('fw:options:init:tabs', {$elements: $this.find('> .builder-items-types')});
 
-		$this.find('> .builder-items-types .builder-item-type').draggable({
+		var additionalSortableOptions = {}
+
+		fwEvents.trigger(
+			'fw-builder:'+ builder.get('type') +':toolbar-sortable-additional-options',
+			additionalSortableOptions
+		)
+
+		$this.find('> .builder-items-types .builder-item-type').draggable(_.extend({
 			connectToSortable: '#'+ id +' .builder-root-items .builder-items',
 			helper: 'clone',
 			distance: 10,
@@ -176,7 +183,7 @@ window.fwExtBuilderInitialize = (function ($) {
 					});
 				}
 			}
-		});
+		}, additionalSortableOptions));
 
 		/**
 		 * Add item on thumbnail click


### PR DESCRIPTION
Fixes the bug when you drag two columns one over another and the drag helper doesn't get removed.

