### PR TITLE
fix for SEO Redirection Premium plugin

### DIFF
--- a/includes/option-types/builder/static/js/initialize-builder.js
+++ b/includes/option-types/builder/static/js/initialize-builder.js
@@ -545,7 +545,7 @@ window.fwExtBuilderInitialize = (function ($) {
 						}
 					},
 					localStorageKey = 'fw-ext-builder-save-scroll-position',
-					$savePostButton = $postForm.find('input#publish'),
+					$savePostButton = $postForm.find('#publishing-action #publish'),
 					$savePostBuilderButton = $(
 						'<button'+
 							' type="button"'+


### PR DESCRIPTION
Hi, I fixed a minor conflict with "SEO Redirection Premium" plugin. On click on this Publish Button: https://static.md/d663cb363ba68774694565ced0d39f39.png was redirected to another page, because this plugin has also a input with this id "publish"